### PR TITLE
fix: ensure service worker returns offline fallback

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -49,6 +49,13 @@ self.addEventListener('fetch', (event) => {
             })
             .catch(() => {
                 console.log('Service Worker: Fetch Failed');
+                // Provide a fallback page so that the fetch handler
+                // always resolves with a valid Response. Without
+                // returning a value here, respondWith would receive
+                // `undefined`, leading to a failed request when the
+                // network is unavailable and the resource isn't in
+                // cache.
+                return caches.match('./index.html');
             })
     );
-}); 
+});


### PR DESCRIPTION
## Summary
- return cached `index.html` when service worker fetches fail

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f8c8532ec8324a4135ac40f1dab27